### PR TITLE
Fix incorrect attack style resetting while meleeing

### DIFF
--- a/demonicgorillas/src/main/java/com/theplug/kotori/demonicgorillas/DemonicGorillaPlugin.java
+++ b/demonicgorillas/src/main/java/com/theplug/kotori/demonicgorillas/DemonicGorillaPlugin.java
@@ -371,7 +371,8 @@ public class DemonicGorillaPlugin extends Plugin
 				{
 					onGorillaAttack(gorilla, DemonicGorilla.AttackStyle.RANGED);
 				}
-				else if (animationId == AnimationID.DEMONIC_GORILLA_AOE_ATTACK && interacting != null)
+				else if (animationId == AnimationID.DEMONIC_GORILLA_AOE_ATTACK && interacting != null &&
+					gorilla.getNextPosibleAttackStyles().stream().anyMatch(x -> x == DemonicGorilla.AttackStyle.MAGIC || x == DemonicGorilla.AttackStyle.RANGED))
 				{
 					// Note that AoE animation is the same as prayer switch animation
 					// so we need to check if the prayer was switched or not.

--- a/demonicgorillas/src/main/java/com/theplug/kotori/demonicgorillas/DemonicGorillaPlugin.java
+++ b/demonicgorillas/src/main/java/com/theplug/kotori/demonicgorillas/DemonicGorillaPlugin.java
@@ -542,12 +542,6 @@ public class DemonicGorillaPlugin extends Plugin
 					gorilla.setDisabledMeleeMovementForTicks(1);
 				}
 			}
-			
-			if (gorilla.getNpc().getOverheadText() != null && gorilla.getNpc().getOverheadText().toLowerCase().contains("rha")) {
-				gorilla.setAttacksUntilSwitch(0);
-				checkGorillaAttackStyleSwitch(gorilla);
-			}
-			
 			gorilla.setLastTickAnimation(gorilla.getNpc().getAnimation());
 			gorilla.setLastWorldArea(gorilla.getNpc().getWorldArea());
 			gorilla.setLastTickInteracting(gorilla.getNpc().getInteracting());
@@ -634,6 +628,11 @@ public class DemonicGorillaPlugin extends Plugin
 				if (shouldDecreaseCounter)
 				{
 					gorilla.setAttacksUntilSwitch(gorilla.getAttacksUntilSwitch() - 1);
+					checkGorillaAttackStyleSwitch(gorilla);
+				}
+				
+				if (gorilla.getNpc().getOverheadText() != null && gorilla.getNpc().getOverheadText().toLowerCase().contains("rha")) {
+					gorilla.setAttacksUntilSwitch(0);
 					checkGorillaAttackStyleSwitch(gorilla);
 				}
 

--- a/demonicgorillas/src/main/java/com/theplug/kotori/demonicgorillas/DemonicGorillaPlugin.java
+++ b/demonicgorillas/src/main/java/com/theplug/kotori/demonicgorillas/DemonicGorillaPlugin.java
@@ -630,11 +630,6 @@ public class DemonicGorillaPlugin extends Plugin
 					gorilla.setAttacksUntilSwitch(gorilla.getAttacksUntilSwitch() - 1);
 					checkGorillaAttackStyleSwitch(gorilla);
 				}
-				
-				if (gorilla.getNpc().getOverheadText() != null && gorilla.getNpc().getOverheadText().toLowerCase().contains("rha")) {
-					gorilla.setAttacksUntilSwitch(0);
-					checkGorillaAttackStyleSwitch(gorilla);
-				}
 
 				it.remove();
 			}

--- a/demonicgorillas/src/main/java/com/theplug/kotori/demonicgorillas/DemonicGorillaPlugin.java
+++ b/demonicgorillas/src/main/java/com/theplug/kotori/demonicgorillas/DemonicGorillaPlugin.java
@@ -542,6 +542,12 @@ public class DemonicGorillaPlugin extends Plugin
 					gorilla.setDisabledMeleeMovementForTicks(1);
 				}
 			}
+			
+			if (gorilla.getNpc().getOverheadText() != null && gorilla.getNpc().getOverheadText().toLowerCase().contains("rha")) {
+				gorilla.setAttacksUntilSwitch(0);
+				checkGorillaAttackStyleSwitch(gorilla);
+			}
+			
 			gorilla.setLastTickAnimation(gorilla.getNpc().getAnimation());
 			gorilla.setLastWorldArea(gorilla.getNpc().getWorldArea());
 			gorilla.setLastTickInteracting(gorilla.getNpc().getInteracting());
@@ -628,11 +634,6 @@ public class DemonicGorillaPlugin extends Plugin
 				if (shouldDecreaseCounter)
 				{
 					gorilla.setAttacksUntilSwitch(gorilla.getAttacksUntilSwitch() - 1);
-					checkGorillaAttackStyleSwitch(gorilla);
-				}
-				
-				if (gorilla.getNpc().getOverheadText() != null && gorilla.getNpc().getOverheadText().toLowerCase().contains("rha")) {
-					gorilla.setAttacksUntilSwitch(0);
 					checkGorillaAttackStyleSwitch(gorilla);
 				}
 

--- a/demonicgorillas/src/main/java/com/theplug/kotori/demonicgorillas/DemonicGorillaPlugin.java
+++ b/demonicgorillas/src/main/java/com/theplug/kotori/demonicgorillas/DemonicGorillaPlugin.java
@@ -630,6 +630,11 @@ public class DemonicGorillaPlugin extends Plugin
 					gorilla.setAttacksUntilSwitch(gorilla.getAttacksUntilSwitch() - 1);
 					checkGorillaAttackStyleSwitch(gorilla);
 				}
+				
+				if (gorilla.getNpc().getOverheadText() != null && gorilla.getNpc().getOverheadText().toLowerCase().contains("rha")) {
+					gorilla.setAttacksUntilSwitch(0);
+					checkGorillaAttackStyleSwitch(gorilla);
+				}
 
 				it.remove();
 			}


### PR DESCRIPTION
This double checks that the gorilla is using magic or ranged when the animation for the boulder fires.

I think when they changed demonic gorillas in may, they also made them randomly use the AOE_ATTACK animation, even while attacking with melee. They also added a overhead text to them, which triggers occasionally, but doesn't have anything to do with the attack styles as far as I can tell.
