### PR TITLE
Adds option to ignore rex prayer if he isn't actively attacking

### DIFF
--- a/dagannothhelper/dagannothhelper.gradle.kts
+++ b/dagannothhelper/dagannothhelper.gradle.kts
@@ -23,7 +23,7 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-version = "2.0.5"
+version = "2.0.6"
 
 project.extra["PluginName"] = "<html><font color=#6b8af6>[K]</font> Dagannoth Helper</html>" // This is the name that is used in the external plugin manager panel
 project.extra["PluginDescription"] = "A plugin for the Dagannoth Kings including overlays and helpers." // This is the description that is used in the external plugin manager panel

--- a/dagannothhelper/src/main/java/com/theplug/kotori/dagannothhelper/DagannothHelperConfig.java
+++ b/dagannothhelper/src/main/java/com/theplug/kotori/dagannothhelper/DagannothHelperConfig.java
@@ -158,6 +158,19 @@ public interface DagannothHelperConfig extends Config
 
 	@ConfigItem(
 			position = 2,
+			keyName = "ignoreRexNonAttackingProtectionPrayer",
+			name = "If Rex isn't attacking, Don't Protect Melee",
+			description = "If Dagannoth Rex isn't actively attacking you, then ignore him." +
+					"<br>Protect Melee will not be automatically turned on.",
+			section = prayerHelper
+	)
+	default boolean ignoreRexNonAttackingProtectionPrayer()
+    {
+        return false;
+    }
+
+	@ConfigItem(
+			position = 3,
 			keyName = "autoOffensiveMeleePrayer",
 			name = "Melee: Auto Offensive Prayer",
 			description = "Automatically turn on your offensive melee prayer when you equip a melee weapon." +
@@ -171,7 +184,7 @@ public interface DagannothHelperConfig extends Config
 	}
 
 	@ConfigItem(
-			position = 3,
+			position = 4,
 			keyName = "autoOffensiveRangedPrayer",
 			name = "Ranged: Auto Offensive Prayer",
 			description = "Automatically turn on your offensive ranged prayer when you equip a ranged weapon." +
@@ -185,7 +198,7 @@ public interface DagannothHelperConfig extends Config
 	}
 
 	@ConfigItem(
-			position = 4,
+			position = 5,
 			keyName = "autoOffensiveMagicPrayer",
 			name = "Magic: Auto Offensive Prayer",
 			description = "Automatically turn on your offensive magic prayer when you equip a magic weapon." +
@@ -199,7 +212,7 @@ public interface DagannothHelperConfig extends Config
 	}
 
 	@ConfigItem(
-			position = 5,
+			position = 6,
 			keyName = "autoPreservePrayer",
 			name = "Turn/Keep Preserve Prayer On",
 			description = "Turn and keep the Preserve prayer on as long as you are in the lair.",

--- a/dagannothhelper/src/main/java/com/theplug/kotori/dagannothhelper/DagannothHelperPlugin.java
+++ b/dagannothhelper/src/main/java/com/theplug/kotori/dagannothhelper/DagannothHelperPlugin.java
@@ -481,6 +481,10 @@ public class DagannothHelperPlugin extends Plugin
 			}
 			else if (ticksUntilAttack == 0)
 			{
+				if (attackStyle == DagannothKing.AttackStyle.MELEE && config.ignoreRexNonAttackingProtectionPrayer())
+				{
+					continue;
+				}
 				attacksWithTicksAtZero.add(attackStyle);
 			}
 		}


### PR DESCRIPTION
Just something i did for myself.

It looked suspicious to be flicking between mage, range and melee when you are actually only fighting prime and supreme because Rex is walking around like an idiot, yet you are still praying melee on everything other tick that prime and supreme aren't attacking.

feel free to merge it if you like it